### PR TITLE
Fixed: Overlapped labels in Accounting transaction pdf export (OFBIZ-…

### DIFF
--- a/applications/order/template/order/CompanyHeader.fo.ftl
+++ b/applications/order/template/order/CompanyHeader.fo.ftl
@@ -35,7 +35,7 @@ under the License.
     </#if>
 
     <#if sendingPartyTaxId?? || phone?? || email?? || website?? || eftAccount??>
-    <fo:list-block provisional-distance-between-starts=".5in">
+    <fo:list-block provisional-distance-between-starts="1in">
         <#if sendingPartyTaxId??>
         <fo:list-item>
             <fo:list-item-label>

--- a/applications/order/template/order/CompanyHeader.fo.ftl
+++ b/applications/order/template/order/CompanyHeader.fo.ftl
@@ -35,74 +35,25 @@ under the License.
     </#if>
 
     <#if sendingPartyTaxId?? || phone?? || email?? || website?? || eftAccount??>
-    <fo:list-block provisional-distance-between-starts="1in">
+    <fo:block>
         <#if sendingPartyTaxId??>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.PartyTaxId}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${sendingPartyTaxId}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
+            <fo:block>${uiLabelMap.PartyTaxId}: ${sendingPartyTaxId}</fo:block>
         </#if>
         <#if phone??>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonTelephoneAbbr}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block><#if phone.countryCode??>${phone.countryCode}-</#if><#if phone.areaCode??>${phone.areaCode}-</#if>${phone.contactNumber!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
+            <fo:block>${uiLabelMap.CommonTelephoneAbbr}: <#if phone.countryCode??>${phone.countryCode}-</#if><#if phone.areaCode??>${phone.areaCode}-</#if>${phone.contactNumber!}</fo:block>
         </#if>
         <#if email??>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonEmail}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${email.infoString!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
+            <fo:block>${uiLabelMap.CommonEmail}: ${email.infoString!}</fo:block>
         </#if>
         <#if website??>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonWebsite}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${website.infoString!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
+            <fo:block>${uiLabelMap.CommonWebsite}: ${website.infoString!}</fo:block>
         </#if>
         <#if eftAccount??>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonFinBankName}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${eftAccount.bankName!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonRouting}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${eftAccount.routingNumber!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
-        <fo:list-item>
-            <fo:list-item-label>
-                <fo:block>${uiLabelMap.CommonBankAccntNrAbbr}:</fo:block>
-            </fo:list-item-label>
-            <fo:list-item-body start-indent="body-start()">
-                <fo:block>${eftAccount.accountNumber!}</fo:block>
-            </fo:list-item-body>
-        </fo:list-item>
+            <fo:block>${uiLabelMap.CommonFinBankName}: ${eftAccount.bankName!}</fo:block>
+            <fo:block>${uiLabelMap.CommonRouting}: ${eftAccount.routingNumber!}</fo:block>
+            <fo:block>${uiLabelMap.CommonBankAccntNrAbbr}: ${eftAccount.accountNumber!}</fo:block>
         </#if>
-    </fo:list-block>
+    </fo:block>
     </#if>
 </fo:block>
 </#escape>


### PR DESCRIPTION
Improved:
Implemented:
Documented:
Completed:
Reverted:
Fixed: Overlapped labels in Accounting transaction pdf export
(OFBIZ-12110)

Explanation

Thanks:
